### PR TITLE
Add google-font support

### DIFF
--- a/layouts/partials/google-fonts.html
+++ b/layouts/partials/google-fonts.html
@@ -1,0 +1,14 @@
+{{ if .Site.Params.google_fonts }}
+  {{ $fonts := slice }}
+  {{ range .Site.Params.google_fonts }}
+    {{ $family := replace (index (.)  0) " " "+" }}
+    {{ $weights := replace (index (.) 1) " " "" }}
+    {{ $string := print $family ":" $weights }}
+    {{ $fonts = $fonts | append $string }}
+  {{ end }}
+  {{ $url_part := (delimit $fonts "|") | safeHTMLAttr }}
+  <link {{ printf "href=\"//fonts.googleapis.com/css?family=%s\"" $url_part | safeHTMLAttr }} rel="stylesheet">
+{{ else}}
+  <!-- specify a default in case custom config not present -->
+  <link href="//fonts.googleapis.com/css?family=Roboto:300,400,700" rel="stylesheet">
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,7 +7,7 @@
   {{ with .Site.Params.description }}
   <meta name="description" content="{{ . }}">
   {{ end }}
-
+  {{ partial "google-fonts" . }}
   {{ $appleTouchIcon := "apple-touch-icon.png" }}
   <link rel="apple-touch-icon" sizes="180x180" href="{{ $appleTouchIcon | absURL }}">
 
@@ -43,4 +43,13 @@
   {{ end }}
 
   {{ partial "style.html" . }}
+  <style>
+    body {
+      font-family: '{{ .Site.Params.body_font }}';
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+      font-family: '{{ .Site.Params.body_font }}';
+    }
+  </style>
 </head>


### PR DESCRIPTION
Follows the gist https://gist.github.com/jeremybise/a6afea2d4c7f9044180ffeb663a617cf but with the following change

- no .scss support so font family declaration lives in `head.html` instead of in its own file
- instead of in `baseof.html` the partial call to `google-font` is also in `head.html`